### PR TITLE
Updated gradle, android-maven-gradle-plugin and android max version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
   - platform-tools
   - tools
-  - build-tools-25.0.2
-  - android-25
+  - build-tools-28.0.3
+  - android-28
   - extra-android-support
   - extra-google-m2repository
   - extra-android-m2repository
@@ -13,8 +13,8 @@ android:
   - ".+"
 before_script:
 - echo yes | android update sdk --no-ui --all --filter platform-tools,tools
-- echo yes | android update sdk --no-ui --all --filter build-tools-25.0.2
-- echo yes | android update sdk --no-ui --all --filter android-25
+- echo yes | android update sdk --no-ui --all --filter build-tools-28.0.3
+- echo yes | android update sdk --no-ui --all --filter android-28
 script:
 - "./gradlew clean test"
 notifications:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.2'
+  compileSdkVersion 28
+  buildToolsVersion '28.0.3'
 
   defaultConfig {
     applicationId "com.mynameismidori.currencypickerexample"
     minSdkVersion 17
-    targetSdkVersion 25
+    targetSdkVersion 28
     versionCode 1
     versionName "1.0"
   }
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-  compile fileTree(include: ['*.jar'], dir: 'libs')
-  compile 'com.android.support:appcompat-v7:25.3.1'
-  compile project(':currencypicker')
+  implementation fileTree(include: ['*.jar'], dir: 'libs')
+  implementation 'com.android.support:appcompat-v7:28.0.0'
+  implementation project(':currencypicker')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,13 @@
 
 buildscript {
   repositories {
+    google()
+    mavenCentral()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+    classpath 'com.android.tools.build:gradle:3.4.1'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
@@ -15,8 +17,10 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
+    google()
+    mavenCentral()
     maven { url "https://jitpack.io" }
+    jcenter()
   }
 }
 

--- a/currencypicker/build.gradle
+++ b/currencypicker/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -22,10 +22,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    testImplementation 'junit:junit:4.12'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 15 10:38:28 IST 2017
+#Sun May 26 23:15:43 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- android-maven-gradle-plugin has released 2.1 version
  https://github.com/dcendents/android-maven-gradle-plugin/releases/tag/2.1
	- google() and mavenCentral() are added to build script as remote repositories
  	  https://developer.android.com/studio/build/dependencies
- gradle build tools is updated to new version 3.4.1
- Dependency configuration deprecations are fixed by refactoring compile and testCompile to implementation and testImplementation
  https://developer.android.com/studio/build/dependencies
- Gradle wrapper is updated from 3.3 to 5.1
- Android Compile SDK version is updated from 25 to 28
  - build Tools updated to 28.0.3
  - appcompat is updated to 28.0.0